### PR TITLE
Add missing -O2 and set openjdk-8 as jdk provider

### DIFF
--- a/recipes-core/openjdk/openjdk-8_60b27-2.5.4.bb
+++ b/recipes-core/openjdk/openjdk-8_60b27-2.5.4.bb
@@ -21,7 +21,7 @@ JDKPN = "openjdk-8"
 JDK_DIR = "java-8-openjdk"
 
 PN = "${JDKPN}-jre"
-PROVIDES += "${JDKPN}"
+PROVIDES += "${JDKPN} ${JDKPN}-jdk"
 
 DEPENDS = " \
            icedtea7-native zip-native ant-native \
@@ -185,7 +185,7 @@ OPENJDK_OECONF = " \
      CFLAGS="--sysroot=${STAGING_DIR_TARGET} " \
      CXXFLAGS="--sysroot=${STAGING_DIR_TARGET} " \
      LDFLAGS="--sysroot=${STAGING_DIR_TARGET} " \
-     --with-extra-cflags="--sysroot=${STAGING_DIR_TARGET} " \
+     --with-extra-cflags="--sysroot=${STAGING_DIR_TARGET} ${SELECTED_OPTIMIZATION}" \
      --with-extra-cxxflags="--sysroot=${STAGING_DIR_TARGET} " \
      --with-extra-ldflags="--sysroot=${STAGING_DIR_TARGET} " \
      "


### PR DESCRIPTION
Without optimizations, build can fail if _FORTIFY_SOURCE is set and warnings are treated as errors, as _FORTIFY_SOURCE requires optimizations.

Also, currently only openjdk-6 is set to provide jdk; 7 and 8 only currently provide jre. This change enables openjdk-8 to provide javac and other development components.

Signed-off-by: Erkka Kääriä <erkka.kaaria@intel.com>