### PR TITLE
openjdk-8: Build fixes

### DIFF
--- a/recipes-core/openjdk/openjdk-8-60b27/icedtea-fix-galileo-build.patch
+++ b/recipes-core/openjdk/openjdk-8-60b27/icedtea-fix-galileo-build.patch
@@ -1,0 +1,11 @@
+--- openjdk/make/common/NativeCompilation.gmk
++++ openjdk/make/common/NativeCompilation.gmk
+@@ -372,7 +372,7 @@ define SetupNativeCompilation
+   $$(foreach p,$$($1_SRCS), \
+       $$(eval $$(call add_native_source,$1,$$p,$$($1_OBJECT_DIR), \
+           $$($1_CFLAGS) $$($1_EXTRA_CFLAGS),$$($1_CC), \
+-          $$($1_CXXFLAGS) $$($1_EXTRA_CXXFLAGS),$(CXX),$$($1_ASFLAGS))))
++          $$($1_CXXFLAGS) $$($1_EXTRA_CXXFLAGS),$$(CXX),$$($1_ASFLAGS))))
+ 
+   # On windows we need to create a resource file
+   ifeq ($(OPENJDK_TARGET_OS), windows)

--- a/recipes-core/openjdk/openjdk-8-60b27/icedtea-fix-zero-mode-undefined-behaviour.patch
+++ b/recipes-core/openjdk/openjdk-8-60b27/icedtea-fix-zero-mode-undefined-behaviour.patch
@@ -1,0 +1,16 @@
+--- openjdk/hotspot/src/os_cpu/linux_zero/vm/os_linux_zero.cpp
++++ openjdk/hotspot/src/os_cpu/linux_zero/vm/os_linux_zero.cpp
+@@ -55,8 +55,8 @@
+ #include "utilities/vmError.hpp"
+ 
+ address os::current_stack_pointer() {
+-  address dummy = (address) &dummy;
+-  return dummy;
++  // return the address of the current function
++  return (address)__builtin_frame_address(0);
+ }
+ 
+ frame os::get_sender_for_C_frame(frame* fr) {
+-- 
+2.1.4
+

--- a/recipes-core/openjdk/openjdk-8_60b27-2.5.4.bb
+++ b/recipes-core/openjdk/openjdk-8_60b27-2.5.4.bb
@@ -572,11 +572,13 @@ OEPATCHES = "\
         "
 
 ICEDTEAPATCHES = "\       
-        file://icedtea-fix-galileo-build.patch;apply=no \ 
+        file://icedtea-fix-galileo-build.patch;apply=no \
+        file://icedtea-fix-zero-mode-undefined-behaviour.patch;apply=no \
         "
 
 DISTRIBUTION_PATCHES = "\
         patches/icedtea-fix-galileo-build.patch \
+        patches/icedtea-fix-zero-mode-undefined-behaviour.patch \
 	"
 
 export DISTRIBUTION_PATCHES

--- a/recipes-core/openjdk/openjdk-8_60b27-2.5.4.bb
+++ b/recipes-core/openjdk/openjdk-8_60b27-2.5.4.bb
@@ -187,7 +187,7 @@ OPENJDK_OECONF = " \
      CFLAGS="--sysroot=${STAGING_DIR_TARGET} ${HOST_CC_ARCH}" \
      CXXFLAGS="--sysroot=${STAGING_DIR_TARGET} ${HOST_CC_ARCH}" \
      LDFLAGS="--sysroot=${STAGING_DIR_TARGET} " \
-     --with-extra-cflags="--sysroot=${STAGING_DIR_TARGET} ${SELECTED_OPTIMIZATION}" \
+     --with-extra-cflags="--sysroot=${STAGING_DIR_TARGET} ${SELECTED_OPTIMIZATION} -DPNG_ARM_NEON_OPT=0" \
      --with-extra-cxxflags="--sysroot=${STAGING_DIR_TARGET} " \
      --with-extra-ldflags="--sysroot=${STAGING_DIR_TARGET} " \
      "

--- a/recipes-core/openjdk/openjdk-8_60b27-2.5.4.bb
+++ b/recipes-core/openjdk/openjdk-8_60b27-2.5.4.bb
@@ -184,8 +184,8 @@ OPENJDK_OECONF = " \
      --disable-headful              \
      --with-sys-root=${STAGING_DIR_TARGET} \
      --with-boot-jdk=${STAGING_LIBDIR_JVM_NATIVE}/icedtea7-native \
-     CFLAGS="--sysroot=${STAGING_DIR_TARGET} " \
-     CXXFLAGS="--sysroot=${STAGING_DIR_TARGET} " \
+     CFLAGS="--sysroot=${STAGING_DIR_TARGET} ${HOST_CC_ARCH}" \
+     CXXFLAGS="--sysroot=${STAGING_DIR_TARGET} ${HOST_CC_ARCH}" \
      LDFLAGS="--sysroot=${STAGING_DIR_TARGET} " \
      --with-extra-cflags="--sysroot=${STAGING_DIR_TARGET} ${SELECTED_OPTIMIZATION}" \
      --with-extra-cxxflags="--sysroot=${STAGING_DIR_TARGET} " \

--- a/recipes-core/openjdk/openjdk-8_60b27-2.5.4.bb
+++ b/recipes-core/openjdk/openjdk-8_60b27-2.5.4.bb
@@ -14,6 +14,7 @@ SRC_URI = " \
   ${JAMVM_URI} \
   ${NASHORN_URI} \
   ${OEPATCHES} \
+  ${ICEDTEAPATCHES} \
   file://jvm.cfg \
   "
 
@@ -569,6 +570,16 @@ OEPATCHES = "\
         file://zero-build.patch;apply=no \
         file://faulty-nx-emulation.patch;apply=no \
         "
+
+ICEDTEAPATCHES = "\       
+        file://icedtea-fix-galileo-build.patch;apply=no \ 
+        "
+
+DISTRIBUTION_PATCHES = "\
+        patches/icedtea-fix-galileo-build.patch \
+	"
+
+export DISTRIBUTION_PATCHES
 
 # overrride the jamvm patch for now, needs to be solved upstream
 do_unpackpost() {


### PR DESCRIPTION
Openjdk builds can currently fail, if CXX also contains assembler arguments. These
arguments are in form "-Wa,args,are,here". When this string is then used in
openjdk make process, it is inserted before the make evaluates its argument
lists. As these lists are comma separated, the commas in assembler argument list
are interpreted as list separators, which breaks the build.

This is fixed by adding the extra '$', which means the string is inserted after
make evaluates the list.

There are also other potential failures:
* -mfloat-abi is not passed to compiler, causing linker error.
* Undefined behaviour in openjdk file os_linux_zero.cpp raises a warning, that then gets promoted to error due to -Werror.
* png_init_filter_functions_neon is not defined during libpng-related tasks.

This are also fixed by passing arguments to compiler, patching the undefined behaviour and by not using machine specific optimizations with libpng.