### PR TITLE
openjdk-8: Solved install issue for libjvm.so

### DIFF
--- a/recipes-core/openjdk/openjdk-8_60b27-2.5.4.bb
+++ b/recipes-core/openjdk/openjdk-8_60b27-2.5.4.bb
@@ -346,7 +346,7 @@ do_install() {
 
         install -m644 ${WORKDIR}/jvm.cfg  ${D}${JDK_HOME}/jre/lib/${JDK_ARCH}/
         # workaround for shared libarary searching
-        ln -sf ${JDK_HOME}/jre/lib/${JDK_ARCH}/server/libjvm.so ${D}${JDK_HOME}/jre/lib/${JDK_ARCH}/
+        ln -sf server/libjvm.so ${D}${JDK_HOME}/jre/lib/${JDK_ARCH}/
 }
 
 # Notes about the ideas behind packaging:


### PR DESCRIPTION
The previous workaround worked only for builds
linked with libjvm.so  that were compiled on target.
It now works, for Yocto packages that require linking
with the JVM library, as well.

Signed-off-by: Andrei Vasiliu <andrei.vasiliu@intel.com>